### PR TITLE
Изменил название титула в Хай Роке

### DIFF
--- a/localization/russian/titles/titles_high_rock_l_russian.yml
+++ b/localization/russian/titles/titles_high_rock_l_russian.yml
@@ -75,7 +75,7 @@
  b_midmoth:0 "Мидмот"
  b_wyrdmarket:0 "Вайрдмаркет"
  b_dresan:0 "Дресан"
- d_anticlere:0 "Рич Грэдкип"
+ d_anticlere:0 "Рейх Градкип"
  c_aldcroft:0 "Альдкрофт"
  b_aldcroft:0 "Альдкрофт"
  b_lightwatch:0 "Светлый Дозор"


### PR DESCRIPTION
Понимаю, что было вынесено на голосование, но, как понимаю, согласно офф. переводу Даггерфолла - это именно "Рейх Градкип". Лучше так, чтобы избежать путаницы, а то получается отсебятина какая-то.